### PR TITLE
Added admin column to Users, removed position column from Users

### DIFF
--- a/db/migrate/20140414184856_change_position_to_admin_on_user.rb
+++ b/db/migrate/20140414184856_change_position_to_admin_on_user.rb
@@ -1,0 +1,6 @@
+class ChangePositionToAdminOnUser < ActiveRecord::Migration
+  def change
+    add_column :users, :admin, :boolean, default: false
+    remove_column :users, :position, :string
+  end
+end

--- a/db/migrate/20140414184856_change_remove_position_add_admin_in_user.rb
+++ b/db/migrate/20140414184856_change_remove_position_add_admin_in_user.rb
@@ -1,6 +1,0 @@
-class ChangeRemovePositionAddAdminInUser < ActiveRecord::Migration
-  def change
-    add_column :users, :admin, :boolean
-    remove_column :users, :position, :string
-  end
-end


### PR DESCRIPTION
New db migration for Users table:

• removed string column "position"
• added boolean column "admin"
